### PR TITLE
Set parameters telling whether gtag or tag_manager is enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "setono/google-analytics-measurement-protocol": "^1.0@alpha",
+        "setono/google-analytics-measurement-protocol": "^1.0.0-alpha.8",
         "setono/tag-bag": "^2.2",
         "setono/tag-bag-bundle": "^3.0",
         "symfony/config": "^5.4 || ^6.0",

--- a/src/DependencyInjection/SetonoGoogleAnalyticsExtension.php
+++ b/src/DependencyInjection/SetonoGoogleAnalyticsExtension.php
@@ -26,9 +26,15 @@ final class SetonoGoogleAnalyticsExtension extends Extension implements PrependE
         $container->setParameter('setono_google_analytics.properties', $config['gtag']['properties']);
         $container->setParameter('setono_google_analytics.containers', $config['tag_manager']['containers']);
         $container->setParameter('setono_google_analytics.consent_enabled', $config['consent']['enabled']);
+        $container->setParameter('setono_google_analytics.gtag_enabled', $config['gtag']['enabled']);
+        $container->setParameter('setono_google_analytics.tag_manager_enabled', $config['tag_manager']['enabled']);
 
         if (true === $config['tag_manager']['enabled'] && true === $config['gtag']['enabled']) {
             throw new \InvalidArgumentException('You cannot enable both gtag and tag_manager at the same time.');
+        }
+
+        if (false === $config['tag_manager']['enabled'] && false === $config['gtag']['enabled']) {
+            throw new \InvalidArgumentException('You must enable either gtag og tag_manager.');
         }
 
         $loader->load('services.xml');
@@ -39,7 +45,9 @@ final class SetonoGoogleAnalyticsExtension extends Extension implements PrependE
 
         if (true === $config['tag_manager']['enabled']) {
             $loader->load('services/conditional/tag_manager_collection_strategy.xml');
-        } else {
+        }
+
+        if (true === $config['gtag']['enabled']) {
             $loader->load('services/conditional/gtag_collection_strategy.xml');
         }
 

--- a/tests/Unit/DependencyInjection/SetonoGoogleAnalyticsExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SetonoGoogleAnalyticsExtensionTest.php
@@ -51,5 +51,7 @@ final class SetonoGoogleAnalyticsExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasParameter('setono_google_analytics.consent_enabled', true);
+        $this->assertContainerBuilderHasParameter('setono_google_analytics.gtag_enabled', true);
+        $this->assertContainerBuilderHasParameter('setono_google_analytics.tag_manager_enabled', false);
     }
 }


### PR DESCRIPTION
This will aid downstream dependencies in figuring out what services to enable/disable based on the collection strategy chosen by the user